### PR TITLE
Add rcl guard condition set on trigger callback

### DIFF
--- a/rcl/CHANGELOG.rst
+++ b/rcl/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rcl
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.1.0 (2022-03-01)
+------------------
 * Add Events Executor (`#839 <https://github.com/ros2/rcl/issues/839>`_)
 * Remove fastrtps customization on test_events (`#960 <https://github.com/ros2/rcl/issues/960>`_)
 * Add client/service QoS getters (`#941 <https://github.com/ros2/rcl/issues/941>`_)

--- a/rcl/CHANGELOG.rst
+++ b/rcl/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package rcl
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add Events Executor (`#839 <https://github.com/ros2/rcl/issues/839>`_)
+* Remove fastrtps customization on test_events (`#960 <https://github.com/ros2/rcl/issues/960>`_)
+* Add client/service QoS getters (`#941 <https://github.com/ros2/rcl/issues/941>`_)
+* introduce ROS_DISABLE_LOAN_MSG to disable can_loan_messages. (`#949 <https://github.com/ros2/rcl/issues/949>`_)
+* Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
+* Contributors: Miguel Company, Shane Loretz, Tomoya Fujita, iRobot ROS, mauropasse
+
 5.0.1 (2022-01-14)
 ------------------
 

--- a/rcl/include/rcl/guard_condition.h
+++ b/rcl/include/rcl/guard_condition.h
@@ -24,6 +24,7 @@ extern "C"
 
 #include "rcl/allocator.h"
 #include "rcl/context.h"
+#include "rcl/event_callback.h"
 #include "rcl/macros.h"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
@@ -47,6 +48,14 @@ typedef struct rcl_guard_condition_options_s
   /// Custom allocator for the guard condition, used for internal allocations.
   rcl_allocator_t allocator;
 } rcl_guard_condition_options_t;
+
+/// On trigger callback data
+typedef struct rcl_guard_condition_callback_data_s
+{
+  rcl_event_callback_t on_trigger_callback;
+  const void * user_data;
+  size_t trigger_count;
+} rcl_guard_condition_callback_data_t;
 
 /// Return a rcl_guard_condition_t struct with members set to `NULL`.
 RCL_PUBLIC
@@ -261,6 +270,34 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rmw_guard_condition_t *
 rcl_guard_condition_get_rmw_handle(const rcl_guard_condition_t * guard_condition);
+
+/// Set the on trigger callback function for the guard_condition.
+/**
+ * This API sets the callback function to be called whenever the
+ * guard_condition is triggered.
+ *
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] guard_condition The guard_condition on which to set the callback
+ * \param[in] on_trigger_callback The callback to be called when guard condition is triggered
+ * \param[in] user_data Given to the callback when called later, may be NULL
+ * \return `RCL_RET_OK` if successful, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if `guard_condition` is NULL, or
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_guard_condition_set_on_trigger_callback(
+  const rcl_guard_condition_t * guard_condition,
+  rcl_event_callback_t on_trigger_callback,
+  const void * user_data);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -318,6 +318,7 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready);
  * \return #RCL_RET_OK if the timer until next call was successfully calculated, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_TIMER_INVALID if the timer is invalid, or
+ * \return #RCL_RET_TIMER_CANCELED if the timer is canceled, or
  * \return #RCL_RET_ERROR an unspecified error occur.
  */
 RCL_PUBLIC

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rcl</name>
-  <version>5.0.1</version>
+  <version>5.1.0</version>
   <description>The ROS client library common implementation.
     This package contains an API which builds on the ROS middleware API and is optionally built upon by the other ROS client libraries.
   </description>

--- a/rcl/src/rcl/guard_condition.c
+++ b/rcl/src/rcl/guard_condition.c
@@ -31,6 +31,7 @@ struct rcl_guard_condition_impl_s
   rmw_guard_condition_t * rmw_handle;
   bool allocated_rmw_guard_condition;
   rcl_guard_condition_options_t options;
+  rcl_guard_condition_callback_data_t callback_data;
 };
 
 rcl_guard_condition_t
@@ -105,7 +106,19 @@ rcl_guard_condition_init(
   const rcl_guard_condition_options_t options)
 {
   // NULL indicates "create a new rmw guard condition".
-  return __rcl_guard_condition_init_from_rmw_impl(guard_condition, NULL, context, options);
+  rcl_ret_t ret = __rcl_guard_condition_init_from_rmw_impl(
+    guard_condition, NULL, context, options);
+
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+
+  // Empty init callback data
+  guard_condition->impl->callback_data.on_trigger_callback = NULL;
+  guard_condition->impl->callback_data.user_data = NULL;
+  guard_condition->impl->callback_data.trigger_count = 0;
+
+  return RCL_RET_OK;
 }
 
 rcl_ret_t
@@ -161,6 +174,15 @@ rcl_trigger_guard_condition(rcl_guard_condition_t * guard_condition)
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     return RCL_RET_ERROR;
   }
+
+  rcl_guard_condition_callback_data_t * cb_data = &guard_condition->impl->callback_data;
+
+  if (cb_data->on_trigger_callback) {
+    cb_data->on_trigger_callback(cb_data->user_data, 1);
+    cb_data->trigger_count = 0;
+  } else {
+    cb_data->trigger_count++;
+  }
   return RCL_RET_OK;
 }
 
@@ -184,6 +206,31 @@ rcl_guard_condition_get_rmw_handle(const rcl_guard_condition_t * guard_condition
     return NULL;  // error already set
   }
   return guard_condition->impl->rmw_handle;
+}
+
+rcl_ret_t
+rcl_guard_condition_set_on_trigger_callback(
+  const rcl_guard_condition_t * guard_condition,
+  rcl_event_callback_t on_trigger_callback,
+  const void * user_data)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(guard_condition, RCL_RET_INVALID_ARGUMENT);
+
+  rcl_guard_condition_callback_data_t * cb_data = &guard_condition->impl->callback_data;
+
+  if (on_trigger_callback) {
+    cb_data->on_trigger_callback = on_trigger_callback;
+    cb_data->user_data = user_data;
+    if (cb_data->trigger_count) {
+      cb_data->on_trigger_callback(user_data, cb_data->trigger_count);
+      cb_data->trigger_count = 0;
+    }
+  } else {
+    cb_data->on_trigger_callback = NULL;
+    cb_data->user_data = NULL;
+  }
+
+  return RCL_RET_OK;
 }
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -297,10 +297,13 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready)
   RCL_CHECK_ARGUMENT_FOR_NULL(is_ready, RCL_RET_INVALID_ARGUMENT);
   int64_t time_until_next_call;
   rcl_ret_t ret = rcl_timer_get_time_until_next_call(timer, &time_until_next_call);
-  if (ret != RCL_RET_OK) {
+  if (ret == RCL_RET_TIMER_CANCELED) {
+    *is_ready = false;
+    return RCL_RET_OK;
+  } else if (ret != RCL_RET_OK) {
     return ret;  // rcl error state should already be set.
   }
-  *is_ready = (time_until_next_call <= 0) && !rcutils_atomic_load_bool(&timer->impl->canceled);
+  *is_ready = (time_until_next_call <= 0);
   return RCL_RET_OK;
 }
 
@@ -309,6 +312,9 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
+  if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
+    return RCL_RET_TIMER_CANCELED;
+  }
   rcl_time_point_value_t now;
   rcl_ret_t ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (ret != RCL_RET_OK) {

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -217,7 +217,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
 
 #define SET_ADD(Type) \
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT); \
-  if (!rcl_wait_set_is_valid(wait_set)) { \
+  if (!wait_set->impl) { \
     RCL_SET_ERROR_MSG("wait set is invalid"); \
     return RCL_RET_WAIT_SET_INVALID; \
   } \
@@ -595,15 +595,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.nsec = min_timeout % 1000000000;
     timeout_argument = &temporary_timeout_storage;
   }
-  RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-    !timeout_argument, ROS_PACKAGE_NAME, "Waiting without timeout");
-  RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-    timeout_argument, ROS_PACKAGE_NAME,
-    "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns",
-    temporary_timeout_storage.sec, temporary_timeout_storage.nsec);
-  RCUTILS_LOG_DEBUG_NAMED(
-    ROS_PACKAGE_NAME, "Timeout calculated based on next scheduled timer: %s",
-    is_timer_timeout ? "true" : "false");
 
   // Wait.
   rmw_ret_t ret = rmw_wait(
@@ -630,7 +621,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     if (ret != RCL_RET_OK) {
       return ret;  // The rcl error state should already be set.
     }
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Timer in wait set is ready");
     if (!is_ready) {
       wait_set->timers[i] = NULL;
     }
@@ -643,8 +633,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl subscription handles NULL.
   for (i = 0; i < wait_set->size_of_subscriptions; ++i) {
     bool is_ready = wait_set->impl->rmw_subscriptions.subscribers[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-      is_ready, ROS_PACKAGE_NAME, "Subscription in wait set is ready");
     if (!is_ready) {
       wait_set->subscriptions[i] = NULL;
     }
@@ -652,8 +640,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl guard_condition handles NULL.
   for (i = 0; i < wait_set->size_of_guard_conditions; ++i) {
     bool is_ready = wait_set->impl->rmw_guard_conditions.guard_conditions[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-      is_ready, ROS_PACKAGE_NAME, "Guard condition in wait set is ready");
     if (!is_ready) {
       wait_set->guard_conditions[i] = NULL;
     }
@@ -661,7 +647,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl client handles NULL.
   for (i = 0; i < wait_set->size_of_clients; ++i) {
     bool is_ready = wait_set->impl->rmw_clients.clients[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Client in wait set is ready");
     if (!is_ready) {
       wait_set->clients[i] = NULL;
     }
@@ -669,7 +654,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl service handles NULL.
   for (i = 0; i < wait_set->size_of_services; ++i) {
     bool is_ready = wait_set->impl->rmw_services.services[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Service in wait set is ready");
     if (!is_ready) {
       wait_set->services[i] = NULL;
     }
@@ -677,7 +661,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl event handles NULL.
   for (i = 0; i < wait_set->size_of_events; ++i) {
     bool is_ready = wait_set->impl->rmw_events.events[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Event in wait set is ready");
     if (!is_ready) {
       wait_set->events[i] = NULL;
     }

--- a/rcl/test/rcl/test_guard_condition.cpp
+++ b/rcl/test/rcl/test_guard_condition.cpp
@@ -251,3 +251,62 @@ TEST_F(
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_trigger_guard_condition(&zero_guard_condition));
   rcl_reset_error();
 }
+
+
+size_t global_trigger_count_ = 0;
+void guard_condition_on_trigger_callback(
+  const void * user_data,
+  size_t trigger_count)
+{
+  (void)user_data;
+  global_trigger_count_ = trigger_count;
+}
+
+/* Test rcl_guard_condition_set_on_trigger_callback
+ */
+TEST_F(
+  CLASSNAME(
+    TestGuardConditionFixture,
+    RMW_IMPLEMENTATION), test_rcl_guard_condition_on_trigger_callback) {
+  rcl_context_t context = rcl_get_zero_initialized_context();
+  rcl_guard_condition_t guard_condition = rcl_get_zero_initialized_guard_condition();
+  rcl_guard_condition_options_t default_options = rcl_guard_condition_get_default_options();
+  rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+  rcl_init_options_init(&init_options, rcl_get_default_allocator());
+  rcl_init(0, nullptr, &init_options, &context);
+  rcl_guard_condition_init(&guard_condition, &context, default_options);
+  // Set on trigger callback to null guard condition
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT,
+    rcl_guard_condition_set_on_trigger_callback(nullptr, nullptr, nullptr));
+  // Trigger 3 times, set callback and check global counter
+  size_t trigger_times = 3;
+  for (size_t i = 0; i < trigger_times; i++) {
+    rcl_trigger_guard_condition(&guard_condition);
+  }
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_guard_condition_set_on_trigger_callback(
+      &guard_condition,
+      guard_condition_on_trigger_callback,
+      nullptr));
+  EXPECT_EQ(global_trigger_count_, trigger_times);
+  // Trigger 1 time and check global counter
+  rcl_trigger_guard_condition(&guard_condition);
+  EXPECT_EQ(global_trigger_count_, static_cast<size_t>(1));
+  // Unset callback
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_guard_condition_set_on_trigger_callback(&guard_condition, nullptr, nullptr));
+  // Trigger 3 times, reset callback and check counter
+  for (size_t i = 0; i < trigger_times; i++) {
+    rcl_trigger_guard_condition(&guard_condition);
+  }
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_guard_condition_set_on_trigger_callback(
+      &guard_condition,
+      guard_condition_on_trigger_callback,
+      nullptr));
+  EXPECT_EQ(global_trigger_count_, trigger_times);
+}

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -497,6 +497,10 @@ TEST_F(TestTimerFixture, test_canceled_timer) {
   ret = rcl_timer_cancel(&timer);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  int64_t time_until_next_call = 0;
+  ret = rcl_timer_get_time_until_next_call(&timer, &time_until_next_call);
+  EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret) << rcl_get_error_string().str;
+
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;

--- a/rcl_action/CHANGELOG.rst
+++ b/rcl_action/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rcl_action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add Events Executor (`#839 <https://github.com/ros2/rcl/issues/839>`_)
+* Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
+* Contributors: Shane Loretz, iRobot ROS
+
 5.0.1 (2022-01-14)
 ------------------
 

--- a/rcl_action/CHANGELOG.rst
+++ b/rcl_action/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rcl_action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.1.0 (2022-03-01)
+------------------
 * Add Events Executor (`#839 <https://github.com/ros2/rcl/issues/839>`_)
 * Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
 * Contributors: Shane Loretz, iRobot ROS

--- a/rcl_action/package.xml
+++ b/rcl_action/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_action</name>
-  <version>5.0.1</version>
+  <version>5.1.0</version>
   <description>Package containing a C-based ROS action implementation</description>
   <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>

--- a/rcl_lifecycle/CHANGELOG.rst
+++ b/rcl_lifecycle/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rcl_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.1.0 (2022-03-01)
+------------------
 * Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
 * Contributors: Shane Loretz
 

--- a/rcl_lifecycle/CHANGELOG.rst
+++ b/rcl_lifecycle/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rcl_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
+* Contributors: Shane Loretz
+
 5.0.1 (2022-01-14)
 ------------------
 * [rcl_lifecycle] Do not share transition event message between nodes (`#956 <https://github.com/ros2/rcl/issues/956>`_)

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_lifecycle</name>
-  <version>5.0.1</version>
+  <version>5.1.0</version>
   <description>Package containing a C-based lifecycle implementation</description>
 
   <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>

--- a/rcl_yaml_param_parser/CHANGELOG.rst
+++ b/rcl_yaml_param_parser/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rcl_yaml_param_parser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+5.1.0 (2022-03-01)
+------------------
 * Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
 * Contributors: Shane Loretz
 

--- a/rcl_yaml_param_parser/CHANGELOG.rst
+++ b/rcl_yaml_param_parser/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rcl_yaml_param_parser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Install includes it include/${PROJECT_NAME} (`#959 <https://github.com/ros2/rcl/issues/959>`_)
+* Contributors: Shane Loretz
+
 5.0.1 (2022-01-14)
 ------------------
 

--- a/rcl_yaml_param_parser/package.xml
+++ b/rcl_yaml_param_parser/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_yaml_param_parser</name>
-  <version>5.0.1</version>
+  <version>5.1.0</version>
   <description>Parse a YAML parameter file and populate the C data structure.</description>
 
   <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>


### PR DESCRIPTION
This branch has the rcl master latest changes plus a commit dc991edcb3ad50c569c98c31ec50d24dcf74ed19 which adds the rcl guard condition `on_trigger_callback`.

This is needed by the `EventsExecutor`'s `TimersManager` to be able to wake when a timer is reset (when a timer is reset it's rcl guard condition is triggered). 

Specifically this is neded by `rclcpp_action::Server` when using the `EventsExecutor` for the `expired_goal` feature, in which an `rcl_timer` is reset after a goal is completed and after some time, the goal is considered expired. 

I'll add a comment with a `rclcpp` PR for the `EventsExecutor`'s `TimersManager` which set the callback to be called by timers when reset.