### PR TITLE
rcl_send_response returns RCL_RET_TIMEOUT. (backport #1048) (#1091)

### DIFF
--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -324,6 +324,7 @@ rcl_take_request(
  * \return #RCL_RET_OK if the response was sent successfully, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_SERVICE_INVALID if the service is invalid, or
+ * \return #RCL_RET_TIMEOUT if a response reader is not ready yet, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -272,6 +272,7 @@ rcl_send_response(
   rmw_request_id_t * request_header,
   void * ros_response)
 {
+  rcl_ret_t ret;
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Sending service response");
   if (!rcl_service_is_valid(service)) {
     return RCL_RET_SERVICE_INVALID;  // error already set
@@ -281,10 +282,12 @@ rcl_send_response(
   const rcl_service_options_t * options = rcl_service_get_options(service);
   RCL_CHECK_FOR_NULL_WITH_MSG(options, "Failed to get service options", return RCL_RET_ERROR);
 
-  if (rmw_send_response(
-      service->impl->rmw_handle, request_header, ros_response) != RMW_RET_OK)
-  {
+  ret = rmw_send_response(service->impl->rmw_handle, request_header, ros_response);
+  if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+    if (ret == RMW_RET_TIMEOUT) {
+      return RCL_RET_TIMEOUT;
+    }
     return RCL_RET_ERROR;
   }
   return RCL_RET_OK;


### PR DESCRIPTION
Cherry-pick backport: 
* rcl_send_response returns RCL_RET_TIMEOUT. (#1048)
(cherry picked from commit c7b394a061a99b2f8ba7c8438e3dd39b488ddc6f)